### PR TITLE
Added option to disable merge of project and Roc Babel configuration

### DIFF
--- a/extensions/roc-plugin-babel/src/roc/index.js
+++ b/extensions/roc-plugin-babel/src/roc/index.js
@@ -73,6 +73,11 @@ export default {
 
             if (userBabelConfig) {
                 return (babelConfig) => {
+                    if (userBabelConfig.roc && userBabelConfig.roc.merge === false) {
+                        log.info('Using only project Babel configuration.');
+                        return userBabelConfig;
+                    }
+
                     const newBabelConfig = merge(babelConfig, userBabelConfig);
                     newBabelConfig.plugins = [
                         ...(userBabelConfig.plugins || []).map(resolve('plugin', directory)),


### PR DESCRIPTION
Using this one can disable the automatic merging of Babel configuration.

__Example__
```json5
// .bablerc
{
  "presets": ["latest"],
  "roc": {
    // Defaults to true
    "merge": false
  }
}
```